### PR TITLE
Fix abandoned package name fabpot/php-cs-fixer

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -9,7 +9,7 @@
   "license"           : "GPL-3.0+",
   "require"           : {
     "laravel/framework"   : "5.2.*",
-    "fabpot/php-cs-fixer" : "^1.11",
+    "friendsofphp/php-cs-fixer" : "^1.11",
     "potsky/microsoft-translator-php-sdk" : "*"
   },
   "require-dev"       : {


### PR DESCRIPTION
When I do a `composer install` I receive the following message :

```
Package fabpot/php-cs-fixer is abandoned, you should avoid using it. Use friendsofphp/php-cs-fixer instead.
```

This PR use the new name: `friendsofphp/php-cs-fixer`