### PR TITLE
Dont expand

### DIFF
--- a/src/Potsky/LaravelLocalizationHelpers/Command/LocalizationMissing.php
+++ b/src/Potsky/LaravelLocalizationHelpers/Command/LocalizationMissing.php
@@ -53,6 +53,13 @@ class LocalizationMissing extends LocalizationAbstract
 	 * @var  array
 	 */
 	protected $never_obsolete_keys = array();
+	
+	/**
+	 * Never expand dots following these keys
+	 *
+	 * @var  string
+	 */
+	protected $dont_expand_keys = array();
 
 	/**
 	 * Never manage these lang files
@@ -105,6 +112,7 @@ class LocalizationMissing extends LocalizationAbstract
 		$this->ignore_lang_files   = Config::get( Localization::PREFIX_LARAVEL_CONFIG . 'ignore_lang_files' );
 		$this->lang_folder_path    = Config::get( Localization::PREFIX_LARAVEL_CONFIG . 'lang_folder_path' );
 		$this->never_obsolete_keys = Config::get( Localization::PREFIX_LARAVEL_CONFIG . 'never_obsolete_keys' );
+		$this->dont_expand_keys    = Config::get( Localization::PREFIX_LARAVEL_CONFIG . 'dont_expand_keys', [] );
 		$this->editor              = Config::get( Localization::PREFIX_LARAVEL_CONFIG . 'editor_command_line' );
 		$this->code_style_fixers   = Config::get( Localization::PREFIX_LARAVEL_CONFIG . 'code_style.fixers' );
 		$this->code_style_level    = Config::get( Localization::PREFIX_LARAVEL_CONFIG . 'code_style.level' );
@@ -375,6 +383,9 @@ class LocalizationMissing extends LocalizationAbstract
 							}
 
 							$key_last_token = explode( '.' , $key );
+							if (in_array($key_last_token[0], $this->dont_expand_keys)) {
+								$key_last_token = explode( '.' , $key, 2 );
+							}
 
 							if ( $this->option( 'translation' ) )
 							{

--- a/src/config/config-laravel5.php
+++ b/src/config/config-laravel5.php
@@ -116,7 +116,23 @@ return array(
 		'dynamic' ,
 		'fields' ,
 	) ,
-
+	
+	
+	/*
+	| Phrases following keys in this array will not get expanded and the translated string will remain as-is.
+	|
+	| Example :
+	|   - in PHP blade code : <span>{{{ trans( "message.phrase.Loading records..." ) }}}</span>
+	|   - in lang/en.message.php :
+	|     - 'phrase.Loading records...' => 'Loading records...',
+	|           ...
+	|   
+	| This only works in conjunction with the -w flag (output-flat)
+	|
+	*/
+	'dont_expand_keys' => array(
+	) ,
+	
 
 	/*
 	|--------------------------------------------------------------------------

--- a/src/config/config.php
+++ b/src/config/config.php
@@ -117,6 +117,22 @@ return array(
 		'dynamic' ,
 		'fields' ,
 	) ,
+	
+	
+	/*
+	| Phrases following keys in this array will not get expanded and the translated string will remain as-is.
+	|
+	| Example :
+	|   - in PHP blade code : <span>{{{ trans( "message.phrase.Loading records..." ) }}}</span>
+	|   - in lang/en.message.php :
+	|     - 'phrase.Loading records...' => 'Loading records...',
+	|           ...
+	|   
+	| This only works in conjunction with the -w flag (output-flat)
+	|
+	*/
+	'dont_expand_keys' => array(
+	) ,
 
 
 	/*


### PR DESCRIPTION
Allow translations in the form __('labels.phrase.Loading records...') to yield a translation of 'Loading records...', by marking 'phrase' as a non-expandable key.
Otherwise, we would end up with an empty translation (the last element of the exploded key).
This, of course, works only in conjunction with the -w flag.

@potsky sorry, I know it's a branch on master. If the idea is ok, tell me where to relocate it and I'll do it. Haven't contributed to anything in a while...