### PR TITLE
Laravel 5.5 Support

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -8,7 +8,7 @@
   ],
   "license"           : "GPL-3.0+",
   "require"           : {
-    "illuminate/support"                  : "5.4.*",
+    "illuminate/support"                  : "5.4.* | 5.5.*",
     "friendsofphp/php-cs-fixer"           : "^1.11",
     "potsky/microsoft-translator-php-sdk" : "*"
   },

--- a/composer.json
+++ b/composer.json
@@ -8,7 +8,7 @@
   ],
   "license"           : "GPL-3.0+",
   "require"           : {
-    "illuminate/support"                  : "5.4.* | 5.5.*",
+    "illuminate/support"                  : "5.5.*",
     "friendsofphp/php-cs-fixer"           : "^1.11",
     "potsky/microsoft-translator-php-sdk" : "*"
   },

--- a/composer.json
+++ b/composer.json
@@ -26,5 +26,12 @@
       "Potsky\\LaravelLocalizationHelpers\\" : "src/"
     }
   },
-  "minimum-stability" : "stable"
+  "minimum-stability" : "stable",
+  "extra": {
+        "laravel": {
+            "providers": [
+                "Potsky\\LaravelLocalizationHelpers\\LaravelLocalizationHelpersServiceProvider"
+            ]
+        }
+    }
 }

--- a/src/Potsky/LaravelLocalizationHelpers/Command/LocalizationClear.php
+++ b/src/Potsky/LaravelLocalizationHelpers/Command/LocalizationClear.php
@@ -48,7 +48,7 @@ class LocalizationClear extends LocalizationAbstract
 	 *
 	 * @return mixed
 	 */
-	public function fire()
+	public function handle()
 	{
 		$days = (int)$this->option( 'days' );
 

--- a/src/Potsky/LaravelLocalizationHelpers/Command/LocalizationFind.php
+++ b/src/Potsky/LaravelLocalizationHelpers/Command/LocalizationFind.php
@@ -57,7 +57,7 @@ class LocalizationFind extends LocalizationAbstract
 	 *
 	 * @return mixed
 	 */
-	public function fire()
+	public function handle()
 	{
 		$lemma   = $this->argument( 'lemma' );
 		$folders = $this->manager->getPath( $this->folders );

--- a/src/Potsky/LaravelLocalizationHelpers/Command/LocalizationMissing.php
+++ b/src/Potsky/LaravelLocalizationHelpers/Command/LocalizationMissing.php
@@ -151,7 +151,7 @@ class LocalizationMissing extends LocalizationAbstract
 	 *
 	 * @return mixed
 	 */
-	public function fire()
+	public function handle()
 	{
 		$folders         = $this->manager->getPath( $this->folders );
 		$this->display   = ! $this->option( 'silent' );

--- a/src/Potsky/LaravelLocalizationHelpers/Command/LocalizationMissing.php
+++ b/src/Potsky/LaravelLocalizationHelpers/Command/LocalizationMissing.php
@@ -275,6 +275,8 @@ class LocalizationMissing extends LocalizationAbstract
 		 */
 		foreach ( LangFile::getLangFiles( $dir_lang , $this->json_languages ) as $langFileType )
 		{
+			if ($langFileType->getTypeVendor()) continue;
+
 			$lang = $langFileType->getLang();
 
 			/**


### PR DESCRIPTION
This pull request makes this package compatible with Laravel 5.5.

It explicitly targets Laravel 5.5 and as the `fire()` method for Commands is now `handle()` it is **not backwards-compatible**. Furthermore, this PR includes support for [package auto-discovery](https://laravel-news.com/package-auto-discovery).

Let me know if you'd like me to make further changes.