### PR TITLE
Test against PHP 7.2 on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 language: php
 
 php:
+  - 7.2
   - 7.1
   - 7.0
 

--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
   "require-dev"       : {
     "orchestra/testbench"    : "3.5.*",
     "phpunit/phpunit"        : "^6.0",
-    "satooshi/php-coveralls" : "dev-master"
+    "satooshi/php-coveralls" : "^2.0"
   },
   "autoload"          : {
     "classmap" : [


### PR DESCRIPTION
As PHP 7.2 is the current stable version of PHP, it'd be helpful to know (whether) this package's tests are passing on PHP 7.2.