### PR TITLE
Laravel 5.6 compatibility

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -8,14 +8,14 @@
   ],
   "license"           : "GPL-3.0+",
   "require"           : {
-    "illuminate/support"                  : "5.5.*",
+    "illuminate/support"                  : "5.6.*",
     "friendsofphp/php-cs-fixer"           : "^2.6",
     "potsky/microsoft-translator-php-sdk" : "*"
   },
   "require-dev"       : {
     "orchestra/testbench"    : "3.5.*",
     "phpunit/phpunit"        : "^6.0",
-    "satooshi/php-coveralls" : "dev-master"
+    "satooshi/php-coveralls" : "^2.0"
   },
   "autoload"          : {
     "classmap" : [

--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
   },
   "require-dev"       : {
     "orchestra/testbench"    : "3.6.*",
-    "phpunit/phpunit"        : "^6.0",
+    "phpunit/phpunit"        : "^7.0",
     "satooshi/php-coveralls" : "^2.0"
   },
   "autoload"          : {

--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
     "potsky/microsoft-translator-php-sdk" : "*"
   },
   "require-dev"       : {
-    "orchestra/testbench"    : "3.5.*",
+    "orchestra/testbench"    : "3.6.*",
     "phpunit/phpunit"        : "^6.0",
     "satooshi/php-coveralls" : "^2.0"
   },


### PR DESCRIPTION
Laravel 5.6 is out and it doesn't seem like much has changed: https://laravel.com/docs/5.6/upgrade **except** PHP >= 7.1.3 being required which results in the build on PHP 7.0 to fail.

It'd be great if this package supported Laravel 5.6!

I'm not sure against which branch I should send the PR to adhere to your versioning scheme: https://github.com/potsky/laravel-localization-helpers#1-installation

Let me know if you'd like me to make any changes!

Also, please see https://github.com/potsky/laravel-localization-helpers/pull/69#issuecomment-366932548 for why I upgraded `satooshi/php-coveralls`.
