### PR TITLE
Update deprecated license identifier

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -6,7 +6,7 @@
       "name" : "Potsky"
     }
   ],
-  "license"           : "GPL-3.0+",
+  "license"           : "GPL-3.0",
   "require"           : {
     "illuminate/support"                  : "5.5.*",
     "friendsofphp/php-cs-fixer"           : "^2.6",


### PR DESCRIPTION
As per https://spdx.org/licenses/GPL-3.0+.html the license identifier `GPL-3.0+` has been deprecated. This PR updates the identifier to `GPL-3.0` whichhelps automated license checking tools verify your package.